### PR TITLE
Forced using scala ver 2.9.2 and added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:precise
+
+WORKDIR /root
+
+ENV repo https://github.com/herry13/cluster-scheduler-simulator
+
+RUN apt-get update && \
+    apt-get -y install apt-transport-https
+
+RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823 && \
+    apt-get update && \
+    apt-get install -y openjdk-7-jre openjdk-7-jdk sbt git && \
+    git clone $repo
+
+CMD ["/bin/bash", "-c", "cd /root/cluster-scheduler-simulator && sbt run"]

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,8 @@ mainClass := Some("Simulation")
 
 scalacOptions += "-deprecation"
 
+scalaVersion := "2.9.2"
+
 // Add a dependency on commons-math for poisson random number generator
 libraryDependencies += "org.apache.commons" % "commons-math" % "2.2"
 


### PR DESCRIPTION
- scalatest 1.7.2 is only compatible with scala version 2.9.2 or below
- added Dockerfile to run the simulation inside docker container by simply:

      $ docker build -t cluster-scheduler-simulator .
      $ docker run -ti cluster-scheduler-simulator